### PR TITLE
[test-argus-branch] Changed header type (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# gRPC-bidirectional-streaming-go 
+## gRPC-bidirectional-streaming-go 
 (tested on Linux-Ubuntu 16.04 Xenial Xerus)
 
 ![go-gRPC bidirectional streaming](https://miro.medium.com/max/700/1*Ug3CAac6nPclg87bxmRBoA.png)
 
 * An example to implement gRPC bidirectional streaming calls using Go and Protobuf
 
-### Requirements
+#### Requirements
 1. protoc (v3.x and above)
 2. go (v1.16)
 3. git


### PR DESCRIPTION
# Backport

This is an automatic backport to `test-argus-branch` of:
 - #6

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)